### PR TITLE
Added fix for xcd error when launching simplefocstudio.py in reamdme

### DIFF
--- a/README.md.bak
+++ b/README.md.bak
@@ -45,15 +45,7 @@ Or if using Anaconda:
 conda activate simplefoc
 python simpleFOCStudio.py
 ```
-If you get the following error 
-```
-qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
-```
-Try the following command
-```
-sudo apt-get install '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
-```
-It worked for me, hopefully it will for you.
+
 
 ### Usage
 *Simple**FOC**Studio* has several useful features:


### PR DESCRIPTION
Hey, when trying to run simplefocstudio.py I got the following error 
```
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
```
So I added the command that helped me fix it.
```
sudo apt-get install '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
```
I'm running it on a Ubuntu VM so maybe it is why it didnt work at first. But at least it is now fixed!